### PR TITLE
fix: change c++ standard of clang-format to c++17

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -277,7 +277,7 @@ SpacesInLineCommentPrefix:
   Minimum:         1
 SpacesInParentheses: false
 SpaceBeforeSquareBrackets: false
-Standard:        Latest
+Standard:        c++17
 TabWidth:        4
 UseTab:  Never
 


### PR DESCRIPTION
<!-- Before creating this pull request, check the questions below: -->  
<!-- 在提出这个 pull request 之前，请勾选下面的问题： -->

- [x] 您的代码是否能够编译通过？
- [x] 您是否检查了目前在 [pull requests](https://github.com/eesast/THUAI5/pulls) 中是否有与你的贡献功能相同的更改？
- [x] 您的贡献是否符合[贡献者代码协议](https://github.com/eesast/THUAI5/blob/dev/CODE_OF_CONDUCT.md)？
- [x] 您的贡献是否符合[开发规则](https://github.com/eesast/THUAI5#%E5%BC%80%E5%8F%91%E8%A7%84%E5%88%99)？  

Discriptions of this pull request:

<!-- If you have something to say about this pull request, delete the sentence 'No additional discription.' below and add your description. -->
<!-- 如果你对这次的 pull request 有一些描述，请删除下面的句子“No additional discription.”并加上你的描述。 -->

Clang-format 使用 C++17 标准进行格式化
