### PR TITLE
refactor(CAPI): :bug: fix mutex using

### DIFF
--- a/CAPI/API/src/logic.cpp
+++ b/CAPI/API/src/logic.cpp
@@ -22,7 +22,7 @@ Logic::Logic(THUAI6::PlayerType type, int64_t ID, THUAI6::ButcherType butcher, T
 
 std::vector<std::shared_ptr<const THUAI6::Butcher>> Logic::GetButchers() const
 {
-    std::lock_guard<std::mutex> lock(mtxBuffer);
+    std::lock_guard<std::mutex> lock(mtxState);
     std::vector<std::shared_ptr<const THUAI6::Butcher>> temp;
     temp.assign(currentState->butchers.begin(), currentState->butchers.end());
     logger->debug("Called GetButchers");
@@ -31,7 +31,7 @@ std::vector<std::shared_ptr<const THUAI6::Butcher>> Logic::GetButchers() const
 
 std::vector<std::shared_ptr<const THUAI6::Human>> Logic::GetHumans() const
 {
-    std::unique_lock<std::mutex> lock(mtxBuffer);
+    std::unique_lock<std::mutex> lock(mtxState);
     std::vector<std::shared_ptr<const THUAI6::Human>> temp;
     temp.assign(currentState->humans.begin(), currentState->humans.end());
     logger->debug("Called GetHumans");
@@ -40,7 +40,7 @@ std::vector<std::shared_ptr<const THUAI6::Human>> Logic::GetHumans() const
 
 std::vector<std::shared_ptr<const THUAI6::Prop>> Logic::GetProps() const
 {
-    std::unique_lock<std::mutex> lock(mtxBuffer);
+    std::unique_lock<std::mutex> lock(mtxState);
     std::vector<std::shared_ptr<const THUAI6::Prop>> temp;
     temp.assign(currentState->props.begin(), currentState->props.end());
     logger->debug("Called GetProps");
@@ -49,28 +49,28 @@ std::vector<std::shared_ptr<const THUAI6::Prop>> Logic::GetProps() const
 
 std::shared_ptr<const THUAI6::Human> Logic::HumanGetSelfInfo() const
 {
-    std::unique_lock<std::mutex> lock(mtxBuffer);
+    std::unique_lock<std::mutex> lock(mtxState);
     logger->debug("Called HumanGetSelfInfo");
     return currentState->humanSelf;
 }
 
 std::shared_ptr<const THUAI6::Butcher> Logic::ButcherGetSelfInfo() const
 {
-    std::unique_lock<std::mutex> lock(mtxBuffer);
+    std::unique_lock<std::mutex> lock(mtxState);
     logger->debug("Called ButcherGetSelfInfo");
     return currentState->butcherSelf;
 }
 
 std::vector<std::vector<THUAI6::PlaceType>> Logic::GetFullMap() const
 {
-    std::unique_lock<std::mutex> lock(mtxBuffer);
+    std::unique_lock<std::mutex> lock(mtxState);
     logger->debug("Called GetFullMap");
     return currentState->gamemap;
 }
 
 THUAI6::PlaceType Logic::GetPlaceType(int32_t CellX, int32_t CellY) const
 {
-    std::unique_lock<std::mutex> lock(mtxBuffer);
+    std::unique_lock<std::mutex> lock(mtxState);
     logger->debug("Called GetPlaceType");
     return currentState->gamemap[CellX][CellY];
 }


### PR DESCRIPTION
<!-- Before creating this pull request, check the questions below: -->  
<!-- 在提出这个 pull request 之前，请勾选下面的问题： -->

- [ ] 您的代码是否能够编译通过？
- [ ] 您是否检查了目前在 [pull requests](https://github.com/eesast/THUAI6/pulls) 中是否有与你的贡献功能相同的更改？
- [ ] 您的贡献是否符合[贡献者代码协议](https://github.com/eesast/THUAI6/blob/dev/CODE_OF_CONDUCT.md)？
- [ ] 您的贡献是否符合[开发规则](https://github.com/eesast/THUAI6#%E5%BC%80%E5%8F%91%E8%A7%84%E5%88%99)？  

Descriptions of this pull request:

<!-- If you have something to say about this pull request, delete the sentence 'No additional discription.' below and add your description. -->
<!-- 如果你对这次的 pull request 有一些描述，请删除下面的句子“No additional discription.”并加上你的描述。 -->

虽然原本的代码也能做到相同的功能（async情况下，交换buffer和current时同时占有`mtxBufer`和`mtxState`），但是更改过之后更符合语意（`mtxState`来控制是否可以访问State中的信息）